### PR TITLE
refactor: consolidated fetching of data into a single thunk

### DIFF
--- a/client/store/experienceData.js
+++ b/client/store/experienceData.js
@@ -4,6 +4,11 @@ import {setHeadlines} from './newsreel'
 import {secrets_NYT_API_KEY } from '../../secrets_frontend'
 import axios from 'axios'
 
+const GET_CURRENT_EXPERIENCE = 'GET_CURRENT_EXPERIENCE'
+
+
+
+
 export const fetchExperienceData = (wikiPageId, wikiPageTitle, headlineQuery) => {
     console.log('params in thunk creator', wikiPageId, wikiPageTitle, headlineQuery)
     return function thunk(dispatch) {
@@ -63,3 +68,4 @@ export const fetchExperienceData = (wikiPageId, wikiPageTitle, headlineQuery) =>
             .catch(err => console.log("there was an issue", err))
     }
 }
+

--- a/client/store/newsreel.js
+++ b/client/store/newsreel.js
@@ -15,21 +15,3 @@ export default (headlines=[], action) => {
   }
 }
 
-// THUNKS 
-export const fetchHeadlines = query => dispatch => {
-  const api_key = secrets_NYT_API_KEY;
-  const fields = 'snippet,lead_paragraph,abstract,headline,keywords,pub_date,document_type,byline,_id,multimedia,news_desk,section_name,source,type_of_material,_id'; 
-  // using options as a way to optionally construct publication date time frame
-  const options = '';
-
-  return axios.get(`https://api.nytimes.com/svc/search/v2/articlesearch.json?q=${query}&sort=newest&${fields}${options}&api-key=${api_key}`)
-  .then(res => {    
-    let headlines = res.data.response.docs;
-    dispatch(setHeadlines(headlines));
-    return axios.post('/api/article', headlines)
-    .then(articles => console.log('Successfully saved articles'))
-    .catch(console.error);
-  })
-  .catch(console.error);
-}
- 


### PR DESCRIPTION
This branch is incorrectly named.  Sorry!  Should be named refactor-data-fetch.  Only the refactor is in this PR.  Will open a new branch to add persistence.  